### PR TITLE
New repo for cicd practice by medium article

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci_cd/CICD-Pipeline"]
+	path = ci_cd/CICD-Pipeline
+	url = https://github.com/awaisAli09/DevOps-learning


### PR DESCRIPTION
article link is: https://utsavdesai26.medium.com/efficiently-deliver-your-maven-project-with-end-to-end-ci-cd-pipeline-for-building-testing-and-a3c8e4a451d6

repo link is: https://github.com/UtsavDesai26/CICD-Pipeline